### PR TITLE
Add norpm package provider and helper class.

### DIFF
--- a/lib/puppet/provider/package/norpm.rb
+++ b/lib/puppet/provider/package/norpm.rb
@@ -1,0 +1,36 @@
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+require 'puppet/provider/package'
+
+Puppet::Type.type(:package).provide :norpm, :source => :rpm, :parent => :rpm do
+  desc "RPM packaging provider that does not install anything."
+
+  def latest
+    @resource.fail "'latest' is unsupported by this provider."
+  end
+
+  def install
+    true
+  end
+
+  def uninstall
+    true
+  end
+
+  def update
+    true
+  end
+
+end

--- a/manifests/package_provider.pp
+++ b/manifests/package_provider.pp
@@ -1,0 +1,39 @@
+# Copyright 2015 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# == Class: tripleo::packages
+#
+# A class that effectively disables distro package installation.
+#
+# === Parameters:
+#
+# [*disable_package_install*]
+#   Defaults to false. Set to true to disable package installation.
+class tripleo::package_provider (
+  $disable_package_install = false,
+) {
+
+  if $disable_package_install {
+    case $::osfamily {
+      'RedHat': {
+        Package { provider => 'norpm' }
+      }
+      default: {
+        warning('tripleo::packages does not support this distribution.')
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This patch adds a new norpm package provider that extends the
Puppet provided default RPM package provider and stubs out
all of the package install, update, purging so that no
packages will get installed. This may be useful when
deploying pre-built images where we effectively just
want to use Puppet for configuration (not installation).

Includes a ::tripleo::package_provider class that will assist
in cleanly disabling package installation via hiera.
